### PR TITLE
Update nodejs.yml

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,11 +3,12 @@ name: Node CI
 on: [push]
 
 jobs:
-  ubuntu:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
 
     strategy:
-      matrix:
+      matrix: 
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [8.x, 10.x, 12.x, 13.x]
 
     steps:
@@ -21,24 +22,7 @@ jobs:
       - name: test & generate coverage report
         run: npm run coverage
       - name: coverage to codecov
-        uses: codecov/codecov-action@v1.0.3
+        uses: codecov/codecov-action@v1
         with: 
           token: ${{secrets.CODECOV_TOKEN}}
 
-  windows:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with: 
-          node-version: ${{ matrix.node-version }}
-      - name: install
-        run: npm install
-      - name: test
-        run: npm t


### PR DESCRIPTION
codecov-action v1.0.4 has been released, so use matrix.os.
https://github.com/codecov/codecov-action/releases/tag/v1.0.4

> Switch from a Docker based action to a JavaScript based action to add support for macOS and Windows builds. This also allows users to run the codecov action with matrix builds.