### PR TITLE
fix: pass cwd to getPreferredPackageManager instead of process.cwd()

### DIFF
--- a/lib/installPackages.js
+++ b/lib/installPackages.js
@@ -10,7 +10,7 @@ async function getPreferredPackageManager({ cwd }) {
 
 export async function installPackages({ cwd, packageSummary }) {
   const dir = cwd ? `cd ${cwd} &&` : ''
-  const packageManager = await getPreferredPackageManager({ cwd: process.cwd() })
+  const packageManager = await getPreferredPackageManager({ cwd })
   const packages = packageSummary.map((summary) => `${summary.typesName}@${summary.latest}`).join(' ')
   const command = `${dir} ${packageManager} ${packageManager === 'yarn' ? 'add -W' : 'install'} -D ${packages}`
   const spinner = ora(`install types...`)

--- a/test/installPackages.test.js
+++ b/test/installPackages.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  execaMock,
+  preferredPMMock,
+  spinnerStartMock,
+  spinnerStopMock,
+  oraMock,
+} = vi.hoisted(() => {
+  const execaMock = vi.fn()
+  const preferredPMMock = vi.fn()
+  const spinnerStartMock = vi.fn()
+  const spinnerStopMock = vi.fn()
+  const oraMock = vi.fn(() => ({
+    start: spinnerStartMock,
+    stop: spinnerStopMock,
+  }))
+
+  return {
+    execaMock,
+    preferredPMMock,
+    spinnerStartMock,
+    spinnerStopMock,
+    oraMock,
+  }
+})
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}))
+
+vi.mock('preferred-pm', () => ({
+  default: preferredPMMock,
+}))
+
+vi.mock('ora', () => ({
+  default: oraMock,
+}))
+
+import { installPackages } from '../lib/installPackages.js'
+
+describe('installPackages', () => {
+  beforeEach(() => {
+    execaMock.mockReset()
+    preferredPMMock.mockReset()
+    oraMock.mockClear()
+    spinnerStartMock.mockClear()
+    spinnerStopMock.mockClear()
+    execaMock.mockResolvedValue({ all: 'ok' })
+  })
+
+  it('falls back to npm when the preferred package manager is unsupported', async () => {
+    preferredPMMock.mockResolvedValue({ name: 'pnpm' })
+
+    await installPackages({
+      cwd: '/tmp/project',
+      packageSummary: [{ typesName: '@types/foo', latest: '1.2.3' }],
+    })
+
+    expect(preferredPMMock).toHaveBeenCalledWith('/tmp/project')
+    expect(execaMock).toHaveBeenCalledWith(
+      'cd /tmp/project && npm install -D @types/foo@1.2.3',
+      expect.objectContaining({
+        shell: true,
+      })
+    )
+    expect(spinnerStartMock).toHaveBeenCalledTimes(1)
+    expect(spinnerStopMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses yarn add -W when yarn is the preferred package manager', async () => {
+    preferredPMMock.mockResolvedValue({ name: 'yarn' })
+
+    await installPackages({
+      cwd: '/tmp/project',
+      packageSummary: [
+        { typesName: '@types/foo', latest: '1.2.3' },
+        { typesName: '@types/bar', latest: '4.5.6' },
+      ],
+    })
+
+    expect(execaMock).toHaveBeenCalledWith(
+      'cd /tmp/project && yarn add -W -D @types/foo@1.2.3 @types/bar@4.5.6',
+      expect.objectContaining({
+        shell: true,
+      })
+    )
+  })
+
+  it('stops the spinner before rethrowing install failures', async () => {
+    const error = new Error('install failed')
+    preferredPMMock.mockResolvedValue(undefined)
+    execaMock.mockRejectedValue(error)
+
+    await expect(
+      installPackages({
+        cwd: '/tmp/project',
+        packageSummary: [{ typesName: '@types/foo', latest: '1.2.3' }],
+      })
+    ).rejects.toThrow('install failed')
+
+    expect(spinnerStopMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Fixed a bug where `installPackages()` passed `process.cwd()` to `getPreferredPackageManager()` instead of the `cwd` parameter, causing incorrect npm/yarn detection when a different directory was specified

## Test plan

- [ ] Verify all 20 tests pass with `npm test`
- [ ] Verify `falls back to npm when the preferred package manager is unsupported` in `test/installPackages.test.js` correctly asserts against `cwd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)