### PR TITLE
ci: skip yarn tests on Windows to reduce build time

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20.x, 22.x, 24.x]
+        include:
+          - os: windows-latest
+            test_pm: npm
 
     steps:
       - uses: actions/checkout@v6
@@ -24,6 +27,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage
+        env:
+          TEST_PM: ${{ matrix.test_pm }}
       - uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
## Summary

- Set `TEST_PM=npm` for Windows runners via matrix `include`
- Windows NTFS has high overhead for extracting node_modules, making sequential yarn tests add ~30-40s with no meaningful coverage benefit over npm tests
- yarn tests continue to run on Ubuntu and macOS

## Test plan

- [ ] Verify Windows build time is reduced compared to ~2-3min
- [ ] Verify Ubuntu and macOS still run both npm and yarn tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)