### PR TITLE
feat: warn when deprecated @types packages are installed

### DIFF
--- a/lib/createPackageSummary.js
+++ b/lib/createPackageSummary.js
@@ -57,12 +57,21 @@ export async function createPackageSummary(options) {
 
       const typesName = isTypes ? pkgName : getTypesName(pkgName)
       const typesPkgFromRegistry = await getPackageFromRegistry(typesName)
-      if (!typesPkgFromRegistry || typesPkgFromRegistry.deprecated) {
+      if (!typesPkgFromRegistry) {
         return
       }
 
       const typesPkgFromNodeModules = await getPackageFromNodeModules(typesName)
-      if (!isTypes && typesPkgFromNodeModules) {
+      const deprecated =
+        typesPkgFromRegistry.deprecated ||
+        (typesPkgFromNodeModules && typesPkgFromNodeModules.deprecated) ||
+        undefined
+
+      if (deprecated && !isTypes && !typesPkgFromNodeModules) {
+        return
+      }
+
+      if (!isTypes && typesPkgFromNodeModules && !deprecated) {
         return
       }
 
@@ -77,7 +86,7 @@ export async function createPackageSummary(options) {
         packageJsonVersion,
         latest,
         satisfies: packageJsonVersion && semver.satisfies(latest, packageJsonVersion),
-        deprecated: typesPkgFromNodeModules ? typesPkgFromNodeModules.deprecated : undefined,
+        deprecated,
       }
     })
   )

--- a/lib/interactiveUpdate.js
+++ b/lib/interactiveUpdate.js
@@ -10,6 +10,14 @@ export async function interactiveUpdate(options) {
   const cwd = options.cwd ? options.cwd : process.cwd()
   const pkg = await readPackage({ cwd })
   const packageSummary = await createPackageSummary({ cwd, pkg })
+
+  const deprecatedPackages = packageSummary.filter((s) => s.deprecated)
+  if (deprecatedPackages.length > 0) {
+    console.log(
+      `${chalk.yellow(`⚠`)} deprecated types installed: ${deprecatedPackages.map((s) => chalk.cyan(s.typesName)).join(', ')}`
+    )
+  }
+
   const choices = createChoices({ packageSummary })
 
   if (!choices.length) {

--- a/test/interactiveUpdate.test.js
+++ b/test/interactiveUpdate.test.js
@@ -69,6 +69,19 @@ describe('interactiveUpdate', () => {
     expect(installPackagesMock).not.toHaveBeenCalled()
   })
 
+  it('warns about installed deprecated types', async () => {
+    createPackageSummaryMock.mockResolvedValue([
+      { typesName: '@types/foo', latest: '1.0.0', deprecated: 'This package is deprecated' },
+    ])
+    createChoicesMock.mockReturnValue([])
+    const spyLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await interactiveUpdate({ cwd: '/tmp/project', update: true })
+
+    expect(spyLog.mock.calls.some(([msg]) => /deprecated/.test(msg) && /@types\/foo/.test(msg))).toBe(true)
+    spyLog.mockRestore()
+  })
+
   it('logs error when installPackages fails', async () => {
     const error = new Error('install failed')
     installPackagesMock.mockRejectedValue(error)


### PR DESCRIPTION
## Summary

- Fixes #22
- Include deprecated-but-installed `@types/` packages in the summary instead of silently skipping them (`createPackageSummary.js`)
- Print a `⚠ deprecated types installed: ...` warning in `interactiveUpdate` before the choice list when such packages are detected
- Add a unit test covering the warning output

## Test plan

- [ ] `pnpm test` passes (all 26 tests)
- [ ] Running `typei` in a project with a deprecated `@types/` package shows the warning line above the choice list

🤖 Generated with [Claude Code](https://claude.com/claude-code)