### PR TITLE
fix: handle ExitPromptError when user presses Ctrl+C during interactive prompt

### DIFF
--- a/lib/interactiveUpdate.js
+++ b/lib/interactiveUpdate.js
@@ -29,16 +29,21 @@ export async function interactiveUpdate(options) {
   if (options.update) {
     selectedPackageSummary = packageSummary
   } else {
-    const answers = await inquirer.prompt([
-      {
-        name: 'types',
-        message: 'choose which types to update',
-        type: 'checkbox',
-        choices,
-        pageSize: process.stdout.rows - 2,
-      },
-    ])
-    selectedPackageSummary = answers.types
+    try {
+      const answers = await inquirer.prompt([
+        {
+          name: 'types',
+          message: 'choose which types to update',
+          type: 'checkbox',
+          choices,
+          pageSize: process.stdout.rows - 2,
+        },
+      ])
+      selectedPackageSummary = answers.types
+    } catch (err) {
+      if (err.name === 'ExitPromptError') return
+      throw err
+    }
   }
 
   if (!selectedPackageSummary.length) {

--- a/test/interactiveUpdate.test.js
+++ b/test/interactiveUpdate.test.js
@@ -92,4 +92,20 @@ describe('interactiveUpdate', () => {
     expect(spyError).toHaveBeenCalledWith(error)
     spyError.mockRestore()
   })
+
+  it('returns silently when user presses Ctrl+C during prompt', async () => {
+    const error = new Error('User force closed the prompt with SIGINT')
+    error.name = 'ExitPromptError'
+    promptMock.mockRejectedValue(error)
+
+    await expect(interactiveUpdate({ cwd: '/tmp/project' })).resolves.toBeUndefined()
+    expect(installPackagesMock).not.toHaveBeenCalled()
+  })
+
+  it('rethrows non-ExitPromptError errors from prompt', async () => {
+    const error = new Error('unexpected error')
+    promptMock.mockRejectedValue(error)
+
+    await expect(interactiveUpdate({ cwd: '/tmp/project' })).rejects.toThrow('unexpected error')
+  })
 })


### PR DESCRIPTION
## Summary

- Wrap `inquirer.prompt()` in a try/catch in `lib/interactiveUpdate.js`
- Return early when `ExitPromptError` is caught (Ctrl+C treated as intentional exit — no error output, exit code 0)
- Rethrow any other unexpected errors

Closes #947

## Test plan

- [ ] Added test: returns silently when user presses Ctrl+C during prompt
- [ ] Added test: rethrows non-ExitPromptError errors from prompt
- [ ] All 28 tests pass